### PR TITLE
[EST-118] 필터 제작 임시저장 API 연동

### DIFF
--- a/src/apis/filterService.ts
+++ b/src/apis/filterService.ts
@@ -1,6 +1,6 @@
-import {AxiosError} from 'axios';
+import {AxiosError, AxiosResponse} from 'axios';
 import {filterInstance} from './instance';
-import {CreateFilterParams} from '@types/filterService.type';
+import {CreateFilterParams, CreateFilterResponse} from '@types/filterService.type';
 
 // 썸네일 불러오기 (GET 테스트 해보려고)
 export const getThumbnail = async (filterId: string, token: string) => {
@@ -19,7 +19,13 @@ export const getThumbnail = async (filterId: string, token: string) => {
 };
 
 // 필터 제작 (multipart/form-data)
-export const createFilter = async ({url, token, thumbnail, representationImg, requestDto}: CreateFilterParams) => {
+export const createFilter = async ({
+  url,
+  token,
+  thumbnail,
+  representationImg,
+  requestDto,
+}: CreateFilterParams): Promise<CreateFilterResponse> => {
   const formData = new FormData();
 
   // 썸네일 파일 추가
@@ -55,7 +61,7 @@ export const createFilter = async ({url, token, thumbnail, representationImg, re
     console.log('성공', response.data);
     console.log('성공 데이터', response.config.data._parts);
     // console.log('formData', formData);
-    return response;
+    return response.data;
   } catch (error) {
     console.log('실패', (error as AxiosError)?.response?.data);
     console.log('실패 데이터', (error as AxiosError)?.config?.data._parts);

--- a/src/screens/ExhibitionCreation/ExhibitionCreationScreen.tsx
+++ b/src/screens/ExhibitionCreation/ExhibitionCreationScreen.tsx
@@ -10,6 +10,8 @@ import arrowIcon from '@assets/icons/arrow.png';
 import checkIcon from '@assets/icons/check.png';
 import useExhibitionCreationStore from '../../store/ExhibitionCreationStore';
 import Carousel from 'react-native-reanimated-carousel';
+import {RootStackParamList} from '@types/navigations';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -18,7 +20,7 @@ interface GalleryItem extends PhotoIdentifier {
 }
 
 function ExhibitionCreationScreen(): React.JSX.Element {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const {selectedImageUri, setSelectedImageUri, additionalImageUri, setAdditionalImageUri} =
     useExhibitionCreationStore();
   const [galleryCursor, setGalleryCursor] = useState<string | undefined>();

--- a/src/screens/FilterCreation/FilterCreationDescScreen.tsx
+++ b/src/screens/FilterCreation/FilterCreationDescScreen.tsx
@@ -25,6 +25,7 @@ import {filterServiceToken} from '@utils/dummy';
 import {CreateFilterParams, CreateFilterResponse, FilterTagType, RequestDto} from '@types/filterService.type';
 import {filterNameToId, filterTagsData} from '@utils/filter';
 import {AxiosError, AxiosResponse} from 'axios';
+import cancelIcon from '@assets/icons/cancel_gray.png';
 
 function FilterCreationDescScreen(): React.JSX.Element {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -201,6 +202,38 @@ function FilterCreationDescScreen(): React.JSX.Element {
             )}
           />
         </View>
+        {/* 선택한 태그가 없을 경우, 빈 화면을 표시합니다. */}
+        {filterTags.length > 0 && (
+          <>
+            <View style={{paddingHorizontal: 20, paddingTop: 15}}>
+              <Text style={{color: '#FFF', fontSize: 13, fontWeight: '500'}}>내가 선택한 태그</Text>
+            </View>
+            <View style={{flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginTop: 10}}>
+              <FlatList
+                horizontal={true}
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{gap: 10}}
+                data={filterTags}
+                renderItem={({item, index}) => (
+                  <View
+                    key={index}
+                    style={[
+                      styles.selectedKeyword,
+                      {
+                        marginLeft: index === 0 ? 20 : 0,
+                        marginRight: index === filterTagsData.length - 1 ? 20 : 0,
+                      },
+                    ]}>
+                    <Text style={styles.selectedKeywordText}>{item}</Text>
+                    <Pressable onPress={() => setFilterTags(filterTags.filter(tag => tag !== item))}>
+                      <Image source={cancelIcon} style={{width: 17, height: 17}} resizeMode="contain" />
+                    </Pressable>
+                  </View>
+                )}
+              />
+            </View>
+          </>
+        )}
         <View style={{gap: 10, marginVertical: 30, paddingHorizontal: 20}}>
           <Text style={{color: '#FFF', fontSize: 14}}>필터를 사용할 사진을 선택해주세요!</Text>
           <View style={{flexDirection: 'row', gap: 10}}>
@@ -283,6 +316,21 @@ const styles = StyleSheet.create({
   keywordText: {
     color: '#F4F4F4',
     fontSize: 16,
+  },
+  selectedKeyword: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 3,
+    borderRadius: 8.5,
+    paddingLeft: 13,
+    paddingRight: 10,
+    paddingVertical: 10,
+    backgroundColor: '#414141',
+  },
+  selectedKeywordText: {
+    color: '#F4F4F4',
+    fontSize: 14,
   },
   imgBox: {
     justifyContent: 'center',

--- a/src/types/filterService.type.ts
+++ b/src/types/filterService.type.ts
@@ -37,11 +37,16 @@ export interface RequestDto {
 }
 
 export interface CreateFilterParams {
-  url: string;
+  url: '' | '/temporary_filter';
   token: string;
   thumbnail: FileData;
   representationImg: FileData[] | [];
   requestDto: RequestDto;
+}
+
+export interface CreateFilterResponse {
+  filter_id: string;
+  created_at: string;
 }
 
 // 필터 기본 정보

--- a/src/types/navigations.ts
+++ b/src/types/navigations.ts
@@ -11,5 +11,6 @@ export type RootStackParamList = {
   FilterCreationDesc: undefined;
   FilterCreationGallery: {type: 'main' | 'sub'; index?: number};
   CameraPage: undefined;
+  ExhibitionFilterApplyAll: undefined;
   // 다른 스크린의 파라미터 타입도 여기에 정의합니다.
 };


### PR DESCRIPTION
- 제목 : [EST-118] 필터 제작 임시저장 API 연동

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 필터 제작 임시저장 API 연동
- 내가 선택한 태그 렌더링
- 타입 지정 (커밋 참고)

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 마이갤러리탭 완성 시 임시저장 API 연동 마무리

  <br/>

## ➕ 이슈 링크

- [EST-118] 필터 제작 임시저장 API 연동

<br/>

[EST-118]: https://blackshoes.atlassian.net/browse/EST-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EST-118]: https://blackshoes.atlassian.net/browse/EST-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ